### PR TITLE
fix: Allow non-whitespace before html tag

### DIFF
--- a/syntaxes/es6.inline.html.json
+++ b/syntaxes/es6.inline.html.json
@@ -15,7 +15,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\s+?(\\w+\\.)?(?:html|\/\\*\\s*html\\s*\\*\/)\\s*)(`)",
+			"begin": "(?x)(\\b(?:\\w+\\.)*(?:html|\/\\*\\s*html\\s*\\*\/)\\s*)(`)",
 			"beginCaptures": {
 				"0": {
 					"name": "string.template.ts, punctuation.definition.string.template.begin.ts"


### PR DESCRIPTION
This extension previously did not highlight template literals if there was no space before the html tag, for example in chained functions.

With this change it now allows cases like this.

Before:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/60393001/150333751-6c48f6d9-cfc2-461c-943a-2bdc5a081212.png">

After:
<img width="390" alt="image" src="https://user-images.githubusercontent.com/60393001/150333596-260ae224-b739-429a-bec5-f02baf804ca7.png">
