### PR TITLE
Added case-insensitivity for better compatibility with other extensions

### DIFF
--- a/syntaxes/es6.inline.css.json
+++ b/syntaxes/es6.inline.css.json
@@ -9,7 +9,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.css",
-			"begin": "(?x)(\\s*?(\\w+\\.)?(?:css|\/\\*\\s*css\\s*\\*\/)\\s*)(`)",
+			"begin": "(?ix)(\\s*?(\\w+\\.)?(?:css|\/\\*\\s*css\\s*\\*\/)\\s*)(`)",
 			"beginCaptures": {
 				"0": {
 					"name": "string.template.ts, punctuation.definition.string.template.begin.ts"

--- a/syntaxes/es6.inline.html.json
+++ b/syntaxes/es6.inline.html.json
@@ -19,7 +19,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\s*?(\\w+\\.)?(?:html|\/\\*\\s*html\\s*\\*\/)\\s*)(`)",
+			"begin": "(?ix)(\\s*?(\\w+\\.)?(?:html|\/\\*\\s*html\\s*\\*\/)\\s*)(`)",
 			"beginCaptures": {
 				"0": {
 					"name": "string.template.ts, punctuation.definition.string.template.begin.ts"

--- a/syntaxes/es6.inline.less.json
+++ b/syntaxes/es6.inline.less.json
@@ -9,7 +9,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.less",
-			"begin": "(?x)(\\s*?(\\w+\\.)?(?:less|\/\\*\\s*less\\s*\\*\/)\\s*)(`)",
+			"begin": "(?ix)(\\s*?(\\w+\\.)?(?:less|\/\\*\\s*less\\s*\\*\/)\\s*)(`)",
 			"beginCaptures": {
 				"0": {
 					"name": "string.template.ts, punctuation.definition.string.template.begin.ts"

--- a/syntaxes/es6.inline.scss.json
+++ b/syntaxes/es6.inline.scss.json
@@ -9,7 +9,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.scss",
-			"begin": "(?x)(\\s*?(\\w+\\.)?(?:scss|\/\\*\\s*scss\\s*\\*\/)\\s*)(`)",
+			"begin": "(?ix)(\\s*?(\\w+\\.)?(?:scss|\/\\*\\s*scss\\s*\\*\/)\\s*)(`)",
 			"beginCaptures": {
 				"0": {
 					"name": "string.template.ts, punctuation.definition.string.template.begin.ts"

--- a/syntaxes/es6.inline.style.json
+++ b/syntaxes/es6.inline.style.json
@@ -9,7 +9,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.style",
-			"begin": "(?x)(\\s*?(\\w+\\.)?(?:style|\/\\*\\s*style\\s*\\*\/)\\s*)(`)",
+			"begin": "(?ix)(\\s*?(\\w+\\.)?(?:style|\/\\*\\s*style\\s*\\*\/)\\s*)(`)",
 			"beginCaptures": {
 				"0": {
 					"name": "string.template.ts, punctuation.definition.string.template.begin.ts"


### PR DESCRIPTION
Added case-insensitivity to tags such as /html/ /css/ etc., for better compatibility with other extensions (e.g., Prettier).

[Issue #44](https://github.com/pushqrdx/vscode-inline-html/issues/44)